### PR TITLE
Update to bring all one-and-done code into the .SYSTEM loader area.

### DIFF
--- a/auxmem.vdu.s
+++ b/auxmem.vdu.s
@@ -637,11 +637,12 @@ VDU12         STZ   FXLINES
 * Clear the graphics screen buffer
 VDU12SOFT     JMP   VDU16                  ; *TEMP*
 
-VDU22G        STA   $C050                  ; Enable Graphics
+VDU22G        JSR   VDU12                  ; Clear text and HGR screen
               STA   $C057                  ; Hi-Res
+              STA   $C050                  ; Enable Graphics
               STA   $C054                  ; PAGE1
               STA   $C00C                  ; Select 40col text
-              JMP   VDU12                  ; Clear text and HGR screen
+              RTS
 
 
 * Clear to EOL, respecting text window boundaries

--- a/mainmem.gfx.s
+++ b/mainmem.gfx.s
@@ -105,7 +105,7 @@ GFXINIT     JSR   FDRAWADDR+0       ; Initialize FDRAW library
             STA   FDRAWADDR+5
             JSR   FDRAWADDR+16      ; FDRAW: SetColor
             STZ   BGCOLOR
-            JSR   FDRAWADDR+22      ; FDRAW: clear HGR screen
+*            JSR   FDRAWADDR+22      ; FDRAW: clear HGR screen
             RTS
 
 * Plot bitmap character on the HGR screen

--- a/mainmem.ldr.s
+++ b/mainmem.ldr.s
@@ -161,7 +161,13 @@ DISCONN     LDA   MACHID
             LDA   #>GSBRK
             STA   $3F0+1
 
-            JMP   START
+            JSR   GFXINIT          ; Initialize FDraw graphics
+
+            TSX                    ; Save SP at $0100 in aux
+            >>>   ALTZP
+            STX   $0100
+            >>>   MAINZP
+            >>>   XF2AUX,AUXMOS1
 
 * Filenames for loaded binaries - we're gonna address these later
 
@@ -194,9 +200,8 @@ UNSUPMSG    ASC   "APPLECORN REQUIRES AN APPLE IIGS, APPLE", 8D
             ASC   "PRESS ANY KEY TO QUIT TO PRODOS", 00
 
 ENDSYSTEM
-*PADDING     DS    $4000-*
 
-; Original APPLECORN.BIN code starts here
+; Original APPLECORN.BIN code started here
 
 *START
 *            LDA   #>AUXADDR        ; Address in aux

--- a/mainmem.menu.s
+++ b/mainmem.menu.s
@@ -11,14 +11,6 @@ ROMTOTL      EQU   $0382              ; Prevent name clash
 ROMTHIS      EQU   $0383
 ROMADDRS     EQU   $0384              ; List of ROM filename addresses
 
-START        JSR   GFXINIT          ; Initialize FDraw graphics
-
-             TSX                    ; Save SP at $0100 in aux
-            >>>   ALTZP
-            STX   $0100
-            >>>   MAINZP
-            >>>   XF2AUX,AUXMOS1
-
 ROMMENU      JSR   HOME               ; Clear screen
              LDX   #0
 :LP0         LDA   TITLE1,X           ; Print title


### PR DESCRIPTION
Remove the HGR clear call from GFXINIT, and relocate the call to VDU12 so that it happens prior to enabling graphics mode in the hardware.
This allows the last parts of the initialization (the call to GFXINIT and the XFER into AUXMOS1) to be moved back into mainmem.ldr.s, where they were originally.