### PR TITLE
Cleanup work following .SYSTEM changes

### DIFF
--- a/auxmem.bytwrd.s
+++ b/auxmem.bytwrd.s
@@ -344,12 +344,13 @@ WORD05IO     LDA   OSINTWS+0              ; X CORRUPTED BY XF2MAIN
 WORD05IO1    >>>   XF2MAIN,MAINRDMEM
 
 * <8000xxxx language memory
-*  ????xxxx main memory RAM paged in via STA $C002
+*  ????xxxx MAIN RAM is activated by writing to RDMAINRAM ($C002)
+*           AUX  RAM us activated by writing to RDCARDRAM ($C003)
 *  ????xxxx main memory ROM paged in via XFER
 
-             STA   $C002                  ; Switch to main memory
+             STA   RDMAINRAM              ; Switch to main memory
 WORD05A      LDA   (OSINTWS)              ; Get byte
-             STA   $C003                  ; Back to aux memory
+             STA   RDCARDRAM              ; Back to aux memory
              STA   (OSCTRL),Y             ; Store it
              RTS
 

--- a/auxmem.chario.s
+++ b/auxmem.chario.s
@@ -105,7 +105,7 @@ KBDINIT      LDX   #DEFBYTEEND-DEFBYTE-1
              BIT   SETV
              JSR   KBDTEST
              BCS   :KBDINITOK                ; Return default MODE=0
-             STA   $C010                     ; Ack. keypress
+             STA   KBDSTRB                   ; Ack. keypress
              TAX                             ; Use keypress as default MODE
 :KBDINITOK   TXA
              RTS
@@ -169,11 +169,11 @@ INKEY5       DEX
 INKEY6       PHY
 *
 * VBLK pulses at 50Hz/60Hz, toggles at 100Hz/120Hz
-             LDX   $C019                     ; Get initial VBLK state
-INKEY8       BIT   $C000
+             LDX   RDVBL                     ; Get initial VBLK state
+INKEY8       BIT   KEYBOARD
              BMI   INKEY4                    ; Key pressed
              TXA
-             EOR   $C019
+             EOR   RDVBL
              BPL   INKEY8                    ; Wait for VBLK change
              BMI   INKEYLP                   ; Loop back to key test
 
@@ -364,15 +364,15 @@ KEYCOPY      LDA   FXTABCHAR                 ; Prepare TAB if no copy cursor
 * Cursors      -> $CC-$CF
 *
 KBDREAD      CLV                             ; VC=return keypress
-KBDTEST      LDA   $C000                     ; VS here to test for keypress
+KBDTEST      LDA   KEYBOARD                  ; VS here to test for keypress
              EOR   #$80                      ; Toggle bit 7
              CMP   #$80
              BCS   KBDDONE                   ; No key pressed
              BVS   KBDDONE                   ; VS=test for keypress
-             STA   $C010                     ; Ack. keypress
-             BIT   $C061
+             STA   KBDSTRB                   ; Ack. keypress
+             BIT   BUTTON0
              BMI   KBDLALT                   ; Left Apple pressed
-             BIT   $C062
+             BIT   BUTTON1
              BMI   KBDRALT                   ; Right Apple pressed
              CMP   #$09
              BEQ   KBDTAB                    ; TAB is dual action TAB/COPY
@@ -398,10 +398,10 @@ KBDLALT      CMP   #$40                      ; Left Apple key pressed
              BCS   KBDCHKESC                 ; >'9'
 KBDFUNC      AND   #$0F                      ; Convert Apple-Num to function key
              ORA   #$80
-             BIT   $C062
+             BIT   BUTTON1
              BPL   KBDCHKESC                 ; Left+Digit       -> $8x
              ORA   #$90                      ; Right+Digit      -> $9x
-             BIT   $C061
+             BIT   BUTTON0
              BPL   KBDCHKESC
              EOR   #$30                      ; Left+Right+Digit -> $Ax
              BRA   KBDCHKESC

--- a/auxmem.init.s
+++ b/auxmem.init.s
@@ -32,11 +32,11 @@ MOSINIT     SEI                              ; Disable IRQ while initializing
             LDX   #$FF                       ; Initialize Alt SP to $1FF
             TXS
 
-            STA   $C005                      ; Make sure we are writing aux
-            STA   $C000                      ; Make sure 80STORE is off
+            STA   WRCARDRAM                  ; Make sure we are writing aux
+            STA   80STOREOFF                 ; Make sure 80STORE is off
 
-            LDA   $C08B                      ; LC RAM Rd/Wt, 1st 4K bank
-            LDA   $C08B
+            LDA   LCBANK1                    ; LC RAM Rd/Wt, 1st 4K bank
+            LDA   LCBANK1
 
 :MODBRA     BRA   :RELOC                     ; NOPped out on first run
             BRA   :NORELOC
@@ -104,9 +104,9 @@ MOSINIT     SEI                              ; Disable IRQ while initializing
 :S7         BRA   :L2
 
 :NORELOC
-:S8         STA   $C00D                      ; 80 col on
-            STA   $C003                      ; Alt charset off
-            STA   $C055                      ; PAGE2
+:S8         STA   SET80VID                   ; 80 col on
+            STA   CLRALTCHAR                 ; Alt charset off (?)
+            STA   PAGE2                      ; PAGE2
             JMP   MOSHIGH                    ; Ensure executing in high memory here
 
 MOSHIGH     SEI                              ; Disable IRQ while initializing
@@ -126,7 +126,7 @@ MOSHIGH     SEI                              ; Disable IRQ while initializing
             DEX
             BPL   :INITPG2
 
-            LDA   $C036                      ; GS speed register
+            LDA   CYAREG                     ; GS speed register
             AND   #$80                       ; Speed bit only
             STA   GSSPEED                    ; In Alt LC for IRQ/BRK hdlr
 
@@ -157,7 +157,7 @@ BYTE8E      PHP                              ; Save CLC=RESET, SEC=Not RESET
             JSR   OSNEWL
             PLP                              ; Get entry type back
             LDA   #$01
-            JMP   AUXADDR
+            JMP   ROMAUXADDR
 
 * OSBYTE $8F - Issue service call
 * X=service call, Y=parameter

--- a/auxmem.misc.s
+++ b/auxmem.misc.s
@@ -35,7 +35,7 @@ ADVALBUF    INX
             BEQ   :ADVALOK         ; Serial input, return 0
             LDX   #$01             ; For outputs, return 1 char free
             RTS
-:ADVALKBD   BIT   $C000            ; Test keyboard data/strobe
+:ADVALKBD   BIT   KEYBOARD         ; Test keyboard data/strobe
             BPL   :ADVALOK         ; No Strobe, return 0
             INX                    ; Strobe, return 1
 :ADVALOK    RTS
@@ -73,7 +73,7 @@ BEEP        PHA
             BNE   :L2              ; 3cy/2cy  (BEEPX-1) * 3cy + 1 * 2cy
 *------------------------------------------------------
 *                                   BEEPX*5-1cy
-            LDA   $C030            ; 4cy        BEEPX*5+5
+            LDA   SPKR             ; 4cy        BEEPX*5+5
             DEY                    ; 2cy        BEEPX*5+7
             BNE   :L1              ; 3cy/2cy    BEEPX*5+10
             PLY                    ;
@@ -361,9 +361,9 @@ EVENT       RTS
 
 * Initialize ROMTAB according to user selection in menu
 ROMINIT     STZ   MAXROM           ; One sideways ROM only
-            STA   $C002            ; Read main mem
+            STA   RDMAINRAM        ; Read main mem
             LDA   USERSEL          ; *TO DO* Should be actual number of ROMs
-            STA   $C003            ; Read aux mem
+            STA   RDCARDRAM        ; Read aux mem
 
             CMP   #6
             BNE   :X1
@@ -387,9 +387,9 @@ GSBRKAUX    >>>   IENTAUX          ; IENTAUX does not do CLI
 IRQBRKHDLR  PHA
 * Mustn't enable IRQs within the IRQ handler
 * Do not use WRTMAIN/WRTAUX macros
-            STA   $C004            ; Write to main memory
+            STA   WRMAINRAM        ; Write to main memory
             STA   $45              ; $45=A for ProDOS IRQ handlers
-            STA   $C005            ; Write to aux memory
+            STA   WRCARDRAM        ; Write to aux memory
 
             TXA
             PHA

--- a/auxmem.oscli.s
+++ b/auxmem.oscli.s
@@ -735,7 +735,7 @@ EXECNOTFND   JMP   ERRNOTFND            ; File not found
 * --------------------
 * Turn Apple II accelerators on
 CMDFAST      LDA   #$80                      ; Apple IIgs
-             TSB   $C036
+             TSB   CYAREG
              STA   GSSPEED
              JSR   ZIPUNLOCK                 ; ZipChip
              JSR   ZIPDETECT
@@ -749,7 +749,7 @@ CMDFAST      LDA   #$80                      ; Apple IIgs
 * --------------------
 * Turn Apple II accelerators off
 CMDSLOW      LDA   #$80                      ; Apple IIgs
-             TRB   $C036
+             TRB   CYAREG
              STZ   GSSPEED
              JSR   ZIPUNLOCK                 ; ZipChip
              JSR   ZIPDETECT

--- a/mainmem.init.s
+++ b/mainmem.init.s
@@ -92,13 +92,13 @@ GSBRK        >>>   XF2AUX,GSBRKAUX
 *:S1          RTS
 *
 * Reset handler - invoked on Ctrl-Reset
-* XFER to AUXMOS ($C000) in aux, AuxZP on, LC on
+* XFER to AUXMOS ($D000) in aux, AuxZP on, LC on
 RESET        TSX
              STX   $0100
-             LDA   $C058             ; AN0 off
-             LDA   $C05A             ; AN1 off
-             LDA   $C05D             ; AN2 on
-             LDA   $C05F             ; AN3 on
+             LDA   AN0OFF            ; AN0 off
+             LDA   AN1OFF            ; AN1 off
+             LDA   AN2ON             ; AN2 on
+             LDA   AN3ON             ; AN3 on
              >>>   XF2AUX,AUXMOS
              RTS
 

--- a/mainmem.ldr.s
+++ b/mainmem.ldr.s
@@ -71,7 +71,7 @@ RTSINST     LDA   CMDPATH
             CMP   #'/'
             BEQ   DISCONN           ; CMDPATH already absolute path
 :GETPFX     JSR   MLI
-             DB   $C7               ; Get Prefix
+             DB   GPFXCMD           ; Get Prefix
              DW   GETPFXPARM
 
 * Disconnect /RAM ramdrive to avoid aux corruption
@@ -154,12 +154,12 @@ DISCONN     LDA   MACHID
             LDA   #>RESET
             STA   RSTV+1
             EOR   #$A5             ; Checksum
-            STA   RSTV+2
+            STA   PWRDUP
 
-            LDA   #<GSBRK          ; Set BRK vector in main mem
-            STA   $3F0
+            LDA   #<GSBRK          ; Set BREAK vector in main mem
+            STA   BREAKV
             LDA   #>GSBRK
-            STA   $3F0+1
+            STA   BREAKV+1
 
             JSR   GFXINIT          ; Initialize FDraw graphics
 
@@ -184,14 +184,14 @@ UNSUPLP     LDA   UNSUPMSG,X
             JSR   COUT1
             INX
             BNE   UNSUPLP
-UNSUPWAIT   STA   $C010
-UNSUPKEY    LDA   $C000
+UNSUPWAIT   STA   KBDSTRB
+UNSUPKEY    LDA   KEYBOARD
             BPL   UNSUPKEY
-            STA   $C010
+            STA   KBDSTRB
 
             JSR   MLI
-            DB    QUITCMD
-            DW    UNSUPQPARM
+             DB   QUITCMD
+             DW   UNSUPQPARM
 UNSUPQPARM  DB    $04,$00,$00,$00,$00,$00,$00
 
 UNSUPMSG    ASC   "APPLECORN REQUIRES AN APPLE IIGS, APPLE", 8D
@@ -200,140 +200,3 @@ UNSUPMSG    ASC   "APPLECORN REQUIRES AN APPLE IIGS, APPLE", 8D
             ASC   "PRESS ANY KEY TO QUIT TO PRODOS", 00
 
 ENDSYSTEM
-
-; Original APPLECORN.BIN code started here
-
-*START
-*            LDA   #>AUXADDR        ; Address in aux
-*            LDX   #<AUXADDR
-*            SEC                    ; Load into aux
-*            JSR   LOADCODE         ; Load lang ROM
-*
-*            JSR   GFXINIT          ; Initialize FDraw graphics
-*
-*            TSX                    ; Save SP at $0100 in aux
-*            >>>   ALTZP
-*            STX   $0100
-*            >>>   MAINZP
-*            >>>   XF2AUX,AUXMOS1
-*
-* Load image from file into memory
-* On entry: OPENPL set up to point to leafname of file to load
-*           Loads file from directory applecorn started from
-*           Uses BLKBUF at loading buffer
-*           Load address in A,X
-*           Carry set->load to aux, carry clear->load to main
-*LOADCODE    PHP                    ; Save carry flag
-*            STA   :ADDRH           ; MSB of load address
-*            STX   :ADDRL           ; LSB of load address
-*            STZ   :BLOCKS
-*
-*            LDX   #0
-*:LP1        LDA   CMDPATH+1,X      ; Copy Applecorn path to MOSFILE
-*            STA   MOSFILE2+1,X
-*            INX
-*            CPX   CMDPATH
-*            BCC   :LP1
-*:LP2        DEX
-*            LDA   MOSFILE2+1,X
-*            CMP   #'/'
-*            BNE   :LP2
-*            LDA   OPENPL+1
-*            STA   A1L
-*            LDA   OPENPL+2
-*            STA   A1H
-*            LDY   #1
-*            LDA   (A1L),Y
-*            CMP   #'/'
-*            BEQ   :L4              ; Already absolute path
-*:LP3        LDA   (A1L),Y
-*            STA   MOSFILE2+2,X
-*            INX
-*            INY
-*            TYA
-*            CMP   (A1L)
-*            BCC   :LP3
-*            BEQ   :LP3
-*            INX
-*            STX   MOSFILE2+0
-*            LDA   #<MOSFILE2       ; Point to absolute path
-*            STA   OPENPL+1
-*            LDA   #>MOSFILE2
-*            STA   OPENPL+2
-*
-*:L4         JSR   OPENFILE         ; Open ROM file
-*            BCC   :S1
-*            PLP
-*            BCC   :L1A             ; Load to main, report error
-*            RTS                    ; Load to aux, return CS=Failed
-*:L1A        LDX   #$00
-*:L1B        LDA   :CANTOPEN,X      ; Part one of error msg
-*            BEQ   :S0
-*            JSR   COUT1
-*            INX
-*            BRA   :L1B
-*:S0         LDA   OPENPL+1         ; Print filename
-*            STA   A1L
-*            LDA   OPENPL+2
-*            STA   A1H
-*            LDY   #$00
-*            LDA   (A1L),Y
-*            STA   :LEN
-*:L1C        CPY   :LEN
-*            BEQ   :ERR1
-*            INY
-*            LDA   (A1L),Y
-*            JSR   COUT1
-*            BRA   :L1C
-*:ERR1       JSR   CROUT
-*            JSR   BELL
-*:SPIN       BRA   :SPIN
-*:S1         LDA   OPENPL+5         ; File reference number
-*            STA   READPL+1
-*:L2         PLP
-*            PHP
-*            BCS   :L2A             ; Loading to aux, skip dots
-*            LDA   #'.'+$80         ; Print progress dots
-*            JSR   COUT1
-*:L2A        JSR   RDFILE           ; Read file block by block
-*            BCS   :CLOSE           ; EOF (0 bytes left) or some error
-*            LDA   #<BLKBUF         ; Source start addr -> A1L,A1H
-*            STA   A1L
-*            LDA   #>BLKBUF
-*            STA   A1H
-*            LDA   #<BLKBUFEND      ; Source end addr -> A2L,A2H
-*            STA   A2L
-*            LDA   #>BLKBUFEND
-*            STA   A2H
-*            LDA   :ADDRL           ; Dest in aux -> A4L, A4H
-*            STA   A4L
-*            LDA   :ADDRH
-*            LDX   :BLOCKS
-*:L3         CPX   #$00
-*            BEQ   :S2
-*            INC
-*            INC
-*            DEX
-*            BRA   :L3
-*:S2         STA   A4H
-*            PLP                    ; Recover carry flag
-*            PHP
-*            BCS   :TOAUX
-*            JSR   MEMCPY           ; Destination in main mem
-*            BRA   :S3
-*:TOAUX      JSR   AUXMOVE          ; Carry already set (so to aux)
-*:S3         INC   :BLOCKS
-*            BRA   :L2
-*:CLOSE      LDA   OPENPL+5         ; File reference number
-*            STA   CLSPL+1
-*            JSR   CLSFILE
-*            JSR   CROUT
-*            PLP
-*            CLC                    ; CC=Ok
-*            RTS
-*:ADDRL      DB    $00              ; Destination address (LSB)
-*:ADDRH      DB    $00              ; Destination address (MSB)
-*:BLOCKS     DB    $00              ; Counter for blocks read
-*:LEN        DB    $00              ; Length of filename
-*:CANTOPEN   ASC   "Unable to open "
-*            DB    $00

--- a/mainmem.menu.s
+++ b/mainmem.menu.s
@@ -20,9 +20,9 @@ ROMMENU      JSR   HOME               ; Clear screen
              BNE   :LP0
 :LP1
 
-:KEYIN       LDA   $C000              ; Kdb data / strobe
+:KEYIN       LDA   KEYBOARD           ; Kdb data / strobe
              BPL   :KEYIN             ; Wait for keystroke
-             STA   $C010              ; Clear strobe
+             STA   KBDSTRB              ; Clear strobe
              AND   #$7F
              SEC
              SBC   #'1'               ; '1'->0, '2'->1 etc.

--- a/mainmem.misc.s
+++ b/mainmem.misc.s
@@ -27,14 +27,14 @@ MEMCPY       LDA   (A1L)
 * Copy 512 bytes from BLKBUF to AUXBLK in aux LC
 COPYAUXBLK   >>>   ALTZP          ; Alt ZP & Alt LC on
              LDY   #$00
-             STA   $C005          ; Write aux mem
+             STA   WRCARDRAM      ; Write aux mem
 :L1          LDA   BLKBUF+$000,Y
              STA   AUXBLK+$000,Y
              LDA   BLKBUF+$100,Y
              STA   AUXBLK+$100,Y
              INY
              BNE   :L1
-             STA   $C004          ; Write main mem
+             STA   WRMAINRAM      ; Write main mem
 :S2          >>>   MAINZP         ; Alt ZP off, ROM back in
 RTSINSTR     RTS
 
@@ -98,12 +98,12 @@ EXISTS       LDA   #<MOSFILE
 * Preserves A
 COPYFB       PHA
              LDX   #$11           ; 18 bytes in FILEBLK
-             STA   $C005          ; Write to aux mem
+             STA   WRCARDRAM      ; Write to aux mem
 :L1          LDA   FILEBLK,X
              STA   OSFILECB,X
              DEX
              BPL   :L1
-             STA   $C004          ; Write to main mem again
+             STA   WRMAINRAM      ; Write to main mem again
              PLA
              RTS
 

--- a/mainmem.svc.s
+++ b/mainmem.svc.s
@@ -359,9 +359,9 @@ GBPB          >>>   ENTMAIN
               LDA   GBPBDAT+1
               STA   ZPMOS+1
               LDA   BLKBUF
-              STA   $C005              ; Write to aux
+              STA   WRCARDRAM          ; Write to aux
               STA   (ZPMOS)            ; Store byte in aux mem
-              STA   $C004              ; Write to main again
+              STA   WRMAINRAM          ; Write to main again
               BRA   :UPDCB
 :WRITE        LDA   #<BLKBUF           ; Start of destination
               STA   A4L
@@ -400,7 +400,7 @@ GBPB          >>>   ENTMAIN
 :ERR
 :ZERO         PLA                      ; Throw away A
               >>>   ALTZP              ; Control block can be in ZP!
-              STA   $C005              ; Write to aux
+              STA   WRCARDRAM          ; Write to aux
               LDA   GBPBAUXCB+0        ; Copy control block back to aux
               STA   $B0+0              ; $B0 in AltZP is temp FS workspace
               LDA   GBPBAUXCB+1
@@ -410,7 +410,7 @@ GBPB          >>>   ENTMAIN
               STA   ($B0),Y
               DEY
               BPL   :L2
-              STA   $C004              ; Write to main again
+              STA   WRMAINRAM          ; Write to main again
               >>>   MAINZP
               >>>   XF2AUX,OSGBPBRET
 
@@ -939,9 +939,9 @@ CHKNOTFND     CMP   #$44               ; Convert ProDOS 'not found'
 
 
 * Quit to ProDOS
-QUIT          INC   $03F4              ; Invalidate powerup byte
-              STA   $C054              ; PAGE2 off
-              STA   $C00E              ; Alt font off
+QUIT          INC   PWRDUP             ; Invalidate powerup byte
+              STA   PAGE1              ; PAGE2 off
+              STA   CLRALTCHAR         ; Alt font off
               JSR   MLI
               DB    QUITCMD
               DW    QUITPL
@@ -1196,8 +1196,8 @@ MULTIDEL      >>>   ENTMAIN
 
 
 * Read machid from auxmem
-MACHRD        LDA   $C081
-              LDA   $C081
+MACHRD        LDA   ROMIN
+              LDA   ROMIN
               LDA   $FBC0
               SEC
               JSR   $FE1F
@@ -1206,8 +1206,8 @@ MACHRD        LDA   $C081
 * Read mainmem from auxmem
 MAINRDMEM     STA   A1L
               STY   A1H
-              LDA   $C081
-              LDA   $C081
+              LDA   ROMIN
+              LDA   ROMIN
               LDA   (A1L)
 MAINRDEXIT    >>>   XF2AUX,NULLRTS     ; Back to an RTS
 


### PR DESCRIPTION
Label-ize absolute references to Apple II I/O locations.
Fix a typo-ed reference to CLRALTCHAR to correct location.
Also removed commented-out LOADCODE routine from `mainmem.ldr.s`, since it's been relocated to `mainmem.menu.s`