### PR TITLE
Current language preserved over Break

### DIFF
--- a/auxmem.init.s
+++ b/auxmem.init.s
@@ -3,6 +3,8 @@
 *
 * Initialization code running in Apple //e aux memory
 * 08-Nov-2022 ResetType OSBYTE set
+* 09-Nov-2022 Current language re-entered, reset on Power/Hard Reset
+* BUG: If Ctrl-Break pressed during a service call, wrong ROM gets paged in
 
 
 ***********************************************************
@@ -10,6 +12,10 @@
 ***********************************************************
 
 MAXROM      EQU   $F9             ; Max sideways ROM number
+FXLANG      EQU   BYTEVARBASE+$FC ; Current language
+FXRESET     EQU   BYTEVARBASE+$FD ; Last Reset type
+FXOPTIONS   EQU   BYTEVARBASE+$FF ; Startup options
+
 
 ZP1         EQU   $90             ; $90-$9f are spare Econet space
                                   ; so safe to use
@@ -30,7 +36,7 @@ MOSSHIM
 *
 * Initially executing at $2000 until copied to $D000
 *
-* When running APLCORN.SYSTEM:
+* When first run from loading from disk:
 *  Code will be at $2000-$4FFF, then copied to $D000-$FFFF
 * When Ctrl-Reset pressed:
 *  AUX RESET code jumps to MAIN $D000
@@ -44,67 +50,109 @@ MOSINIT     SEI                   ; Ensure IRQs disabled
 
             LDA   LCBANK1         ; LC RAM Rd/Wt, 1st 4K bank
             LDA   LCBANK1
-            LDY   #$00            ; $02=Soft Reset
+            LDY   #$00            ; $00=Soft Reset
 :MODBRA     BRA   :RELOC          ; NOPped out on first run
             BRA   :NORELOC
 
-:RELOC      LDA   #<AUXMOS1       ; Relocate MOS shim
+:RELOC      LDA   #<AUXMOS1       ; Source
             STA   A1L
             LDA   #>AUXMOS1
             STA   A1H
-            LDA   #<EAUXMOS1
+            LDA   #<AUXMOS        ; Dest
             STA   A2L
-            LDA   #>EAUXMOS1
-            STA   A2H
-            LDA   #<AUXMOS
-            STA   A4L
             LDA   #>AUXMOS
-            STA   A4H
-:L1         LDA   (A1L)
-            STA   (A4L)
-            LDA   A1H
-            CMP   A2H
-            BNE   :S1
-            LDA   A1L
-            CMP   A2L
-            BNE   :S1
-            BRA   :S4
-:S1         INC   A1L
-            BNE   :S2
-            INC   A1H
-:S2         INC   A4L
-            BNE   :S3
-            INC   A4H
-:S3         BRA   :L1
+            STA   A2H             ; Y=0 from earlier
+:L1         LDA   (A1L),Y         ; Copy from source
+            STA   (A2L),Y         ; to dest
+            INY
+            BNE   :L1             ; Do 256 bytes
+            INC   A1H             ; Update source
+            INC   A2H             ; Update dest
+            BMI   :L1             ; Loop until wrap past &FFFF
+*
+:L2         LDA   MOSVEND-AUXMOS+AUXMOS1-256,Y
+            STA   $FF00,Y         ; Copy MOS API and vectors
+            INY                   ; to proper place
+            BNE   :L2
 
-:S4         LDA   #<MOSVEC-MOSINIT+AUXMOS1
-            STA   A1L
-            LDA   #>MOSVEC-MOSINIT+AUXMOS1
-            STA   A1H
-            LDA   #<MOSVEND-MOSINIT+AUXMOS1
-            STA   A2L
-            LDA   #>MOSVEND-MOSINIT+AUXMOS1
-            STA   A2H
-            LDA   #<MOSAPI
-            STA   A4L
-            LDA   #>MOSAPI
-            STA   A4H
-:L2         LDA   (A1L)
-            STA   (A4L)
-            LDA   A1H
-            CMP   A2H
-            BNE   :S5
-            LDA   A1L
-            CMP   A2L
-            BNE   :S5
-            BRA   :S8
-:S5         INC   A1L
-            BNE   :S6
-            INC   A1H
-:S6         INC   A4L
-            BNE   :S7
-            INC   A4H
-:S7         BRA   :L2
+*:S4         LDA   #<MOSVEC-MOSINIT+AUXMOS1
+*            STA   A1L
+*            LDA   #>MOSVEC-MOSINIT+AUXMOS1
+*            STA   A1H
+*            LDA   #<MOSVEND-MOSINIT+AUXMOS1
+*            STA   A2L
+*            LDA   #>MOSVEND-MOSINIT+AUXMOS1
+*            STA   A2H
+*            LDA   #<MOSAPI
+*            STA   A4L
+*            LDA   #>MOSAPI
+*            STA   A4H
+*:L2         LDA   (A1L)
+*            STA   (A4L)
+*            LDA   A1H
+*            CMP   A2H
+*            BNE   :S5
+*            LDA   A1L
+*            CMP   A2L
+*            BNE   :S5
+
+*            LDA   #<AUXMOS1       ; Relocate MOS shim
+*            STA   A1L
+*            LDA   #>AUXMOS1
+*            STA   A1H
+*            LDA   #<EAUXMOS1
+*            STA   A2L
+*            LDA   #>EAUXMOS1
+*            STA   A2H
+*            LDA   #<AUXMOS
+*            STA   A4L
+*            LDA   #>AUXMOS
+*            STA   A4H
+*:L1         LDA   (A1L)
+*            STA   (A4L)
+*            LDA   A1H
+*            CMP   A2H
+*            BNE   :S1
+*            LDA   A1L
+*            CMP   A2L
+*            BNE   :S1
+*            BRA   :S4
+*:S1         INC   A1L
+*            BNE   :S2
+*            INC   A1H
+*:S2         INC   A4L
+*            BNE   :S3
+*            INC   A4H
+*:S3         BRA   :L1
+*
+*:S4         LDA   #<MOSVEC-MOSINIT+AUXMOS1
+*            STA   A1L
+*            LDA   #>MOSVEC-MOSINIT+AUXMOS1
+*            STA   A1H
+*            LDA   #<MOSVEND-MOSINIT+AUXMOS1
+*            STA   A2L
+*            LDA   #>MOSVEND-MOSINIT+AUXMOS1
+*            STA   A2H
+*            LDA   #<MOSAPI
+*            STA   A4L
+*            LDA   #>MOSAPI
+*            STA   A4H
+*:L2         LDA   (A1L)
+*            STA   (A4L)
+*            LDA   A1H
+*            CMP   A2H
+*            BNE   :S5
+*            LDA   A1L
+*            CMP   A2L
+*            BNE   :S5
+*            BRA   :S8
+*:S5         INC   A1L
+*            BNE   :S6
+*            INC   A1H
+*:S6         INC   A4L
+*            BNE   :S7
+*            INC   A4H
+*:S7         BRA   :L2
 
 :S8
             LDA   #$EA            ; NOP opcode
@@ -124,13 +172,15 @@ MOSHIGH     SEI                   ; Ensure IRQs disabled
             LDX   #$FF
             TXS                   ; Initialise stack
             INX                   ; X=$00
-            TXA
-:SCLR       STA   $0000,X         ; Clear Kernel memory
-            STA   $0200,X
-            STA   $0300,X
+            LDA   FXLANG          ; Y=ResetType, A=Language
+
+:SCLR       STZ   $0000,X         ; Clear Kernel memory
+            STZ   $0200,X
+            STZ   $0300,X
             INX
             BNE   :SCLR
-            STY   BYTEVARBASE+$FD ; Set ResetType
+            STY   FXRESET         ; Set ResetType
+            STA   FXLANG          ; Current language
 
             LDX   #ENDVEC-DEFVEC-1
 :INITPG2    LDA   DEFVEC,X        ; Set up vectors
@@ -146,19 +196,33 @@ MOSHIGH     SEI                   ; Ensure IRQs disabled
             JSR   KBDINIT         ; Returns A=startup MODE
             JSR   VDUINIT         ; Initialise VDU driver
             JSR   PRHELLO
-            LDA   BYTEVARBASE+$FD ; Get ResetType
-            BEQ   :INITSOFT
-            LDA   #7              ; Beep on HardReset
+            JSR   OSNEWL
+            LDA   FXRESET         ; Get ResetType
+            BEQ   :INITSOFT       ; Soft reset, skip past
+            LDA   #7              ; Beep on HardReset/PowerReset
             JSR   OSWRCH
+            LDA   #$FF
+            STA   FXLANG          ; Current language=none
+*
 * AppleII MOS beeps anyway, so always get a Beep
-* BRUN APPLECORN -> BBC Beep
-* Ctrl-Reset -> AppleII Beep
+* APPLECORN startup -> BBC Beep
+* Press Ctrl-Reset  -> AppleII Beep
 *
-:INITSOFT   JSR   OSNEWL
-            LDX   MAXROM          ; *TEMP* X=language to enter
-* TO DO: SoftReset->Use CURRLANG, HardReset->Search for language
+* Find a language to enter
+:INITSOFT   LDX   FXLANG          ; Get current language
+            BPL   :INITLANG       ; b7=ok, use it
+            LDX   ROMMAX          ; Look for a language
+:FINDLANG   JSR   ROMSELECT       ; Bring ROM X into memory
+            BIT   $8006           ; Check ROM type
+            BVS   :INITLANG       ; b6=set, use it
+            DEX                   ; Step down to next ROM
+            BPL   :FINDLANG       ; Loop until all tested
+            BRK                   ; No language found
+            DB    $F9
+            ASC   'No Language'
+            BRK
 *
-            CLC                   ; CLC=Entering from RESET
+:INITLANG   CLC                   ; CLC=Entering from RESET
 
 * OSBYTE $8E - Enter language ROM
 *********************************
@@ -166,6 +230,7 @@ MOSHIGH     SEI                   ; Ensure IRQs disabled
 *
 BYTE8E      PHP                   ; Save CLC=RESET, SEC=Not RESET
             JSR   ROMSELECT       ; Bring ROM X into memory
+            STX   FXLANG          ; Set as current language ROM
             LDA   #$00
             STA   FAULT+0
             LDA   #$80
@@ -175,7 +240,6 @@ BYTE8E      PHP                   ; Save CLC=RESET, SEC=Not RESET
             STY   FAULT+0         ;  FAULT pointing to version string
             JSR   OSNEWL
             JSR   OSNEWL
-            STX   BYTEVARBASE+$FC ; Set current language ROM
             PLP                   ; Get entry type back
             LDA   #$01            ; $01=Entering code with a header
             JMP   ROMAUXADDR
@@ -186,8 +250,8 @@ BYTE8E      PHP                   ; Save CLC=RESET, SEC=Not RESET
 * X=service call, Y=parameter
 *
 * SERVICE     TAX                   ; Enter here with A=Service Num
-BYTE8F
-SERVICEX    LDA   $F4             ; Enter here with X=Service Number
+SERVICEX
+BYTE8F      LDA   $F4             ; Enter here with X=Service Number
             PHA                   ; Save current ROM
 *DEBUG
             LDA   $E0
@@ -198,7 +262,7 @@ SERVICEX    LDA   $F4             ; Enter here with X=Service Number
 :SERVDEBUG
 *DEBUG
             TXA                   ; A=service number
-            LDX   MAXROM          ; Start at highest ROM
+            LDX   ROMMAX          ; Start at highest ROM
 :SERVLP     JSR   ROMSELECT       ; Bring it into memory
             BIT   $8006
             BPL   :SERVSKIP       ; No service entry
@@ -226,7 +290,7 @@ BYTE00      BEQ   BYTE00A         ; OSBYTE 0,0 - generate error
             RTS                   ; %000x1xxx host type, 'A'pple
 BYTE00A     BRK
             DB    $F7
-HELLO       ASC   'Applecorn MOS 2022-11-08'
+HELLO       ASC   'Applecorn MOS 2022-11-04'
             DB    $00             ; Unify MOS messages
 * TO DO: Move into RAM
 GSSPEED     DB    $00             ; $80 if GS is fast, $00 for slow


### PR DESCRIPTION
Startup (power-on) searches for highest language
Ctrl-Break (soft reset) uses current language.
Also tidied up copying code into high memory.